### PR TITLE
Add pytest fixture support

### DIFF
--- a/python/webdriver_test.py
+++ b/python/webdriver_test.py
@@ -34,15 +34,15 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 @pytest.fixture
-def setup(request):
-    request.b = webdriver.Firefox()
+def browser(request):
+    driver = webdriver.Firefox()
     def teardown():
-        request.b.quit()
+        driver.quit()
     request.addfinalizer(teardown)
-    return request
+    return driver
 
-def test_01(setup):
-    b = setup.b
+def test_01(browser):
+    b = browser
     b.get("https://docs.python.org/")
     e = b.find_element_by_link_text('Tutorial')
     e.click()

--- a/python/webdriver_test.py
+++ b/python/webdriver_test.py
@@ -42,10 +42,9 @@ def browser(request):
     return driver
 
 def test_01(browser):
-    b = browser
-    b.get("https://docs.python.org/")
-    e = b.find_element_by_link_text('Tutorial')
-    e.click()
-    element = WebDriverWait(b, 10).until(
+    browser.get("https://docs.python.org/")
+    element = browser.find_element_by_link_text('Tutorial')
+    element.click()
+    element = WebDriverWait(browser, 10).until(
         EC.presence_of_element_located((By.ID, "the-python-tutorial"))
     )

--- a/python/webdriver_test.py
+++ b/python/webdriver_test.py
@@ -27,20 +27,25 @@ git commit -m "Initial revision of webdriver test"
 git push origin master
 
 """
+import pytest
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-def test_01():
-    b = webdriver.Firefox()
+@pytest.fixture
+def setup(request):
+    request.b = webdriver.Firefox()
+    def teardown():
+        request.b.quit()
+    request.addfinalizer(teardown)
+    return request
+
+def test_01(setup):
+    b = setup.b
     b.get("https://docs.python.org/")
     e = b.find_element_by_link_text('Tutorial')
     e.click()
-    try:
-        element = WebDriverWait(b, 10).until(
-            EC.presence_of_element_located((By.ID, "the-python-tutorial"))
-        )
-    finally:
-        b.quit()
-
+    element = WebDriverWait(b, 10).until(
+        EC.presence_of_element_located((By.ID, "the-python-tutorial"))
+    )


### PR DESCRIPTION
Currently test has no setup/teardown workflow.

Add pytest's builtin fixture support in order to provide ability to
execute [setup] and [teardown] steps before and after each test case run.